### PR TITLE
Replace cursor hero image with long version

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,7 +7,7 @@ import Compose from '../public/work/skiff/compose-modal.jpg';
 import Brain from '../public/project-covers/natural.jpg';
 import Azuki from '../public/project-covers/azuki.jpg';
 import CollectorStatus from '../public/project-covers/collector-status.jpg';
-import Cursor from '../public/project-covers/cursor.jpg';
+import Cursor from '../public/project-covers/cursor-long.jpg';
 import NotionCalendar from '../public/project-covers/notion-calendar.jpg';
 import AIGA from '../public/project-covers/aiga-square.jpg';
 import Metalink from '../public/project-covers/metalink.jpg';


### PR DESCRIPTION
Replace `cursor.jpg` with `cursor-long.jpg` for the Cursor project card on the homepage.

The user requested to use the `cursor-long` image for the Cursor project hero. While the dedicated project page (`/pages/cursor.js`) already used `cursor-long.jpg`, the homepage project card (`/pages/index.js`) was still importing and displaying `cursor.jpg`. This change ensures consistency across the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3a3cfc5-804c-4fe9-af0e-2ea60159634b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3a3cfc5-804c-4fe9-af0e-2ea60159634b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- devin-review-badge-begin -->

---

<a href="https://staging.itsdev.in/review/josephz-me/portfolio-v4/pull/22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
