### PR TITLE
Update homepage acquisition text

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -75,7 +75,7 @@ export default function Home() {
               First full-time design hire. 0→1 design for Email, Editor, Drive, Calendar. Scaled
               Skiff Mail to 1M+ users. Recently{' '}
               <TextLink link="https://www.notion.so/blog/meet-skiff-the-newest-member-of-the-notion-family">
-                acquired by Notion HQ
+                acquired by Notion
               </TextLink>
               .
             </WorkExperience>


### PR DESCRIPTION
Remove "HQ" from "Acquired by Notion HQ" text on the homepage as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-42a292b5-a91e-4aad-b623-9c1c1bd3b463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42a292b5-a91e-4aad-b623-9c1c1bd3b463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

