### PR TITLE
Apply progressive blur to div edge

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -15,6 +15,14 @@ export default function Page({ meta, ...props }) {
         </div>
       </div>
       <Footer />
+      <div 
+        className="fixed bottom-0 left-0 right-0 h-10 z-10 backdrop-blur-md"
+        style={{
+          maskImage: 'linear-gradient(to bottom, black 0%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 100%)',
+          background: 'linear-gradient(to bottom, white 0%, transparent 100%)'
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
Add a `div` with a progressive blur effect to the bottom of the page, sharp at the top and blurry at the bottom edge.

---
<a href="https://cursor.com/background-agent?bcId=bc-f54f5638-e6d6-46ac-80e0-d28b6007f1b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f54f5638-e6d6-46ac-80e0-d28b6007f1b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

