### PR TITLE
fix: remove duplicate useRouter call in Navbar component

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,7 +7,7 @@ export default function Navbar(props) {
   const router = useRouter();
   const [activeBack, setActiveBack] = useState(false);
 
-  const pageName = useRouter().asPath;
+  const pageName = router.asPath;
 
   const [scrollY, setScrollY] = useState(0);
   useEffect(() => {


### PR DESCRIPTION
## Summary

Removes a redundant `useRouter()` call in the Navbar component. The component was calling `useRouter()` twice - once to get the router instance and again just to access `asPath`. This change reuses the existing `router` instance instead.

**Before:**
```javascript
const router = useRouter();
const pageName = useRouter().asPath;
```

**After:**
```javascript
const router = useRouter();
const pageName = router.asPath;
```

## Review & Testing Checklist for Human

- [ ] Verify the navbar renders correctly on the homepage and project pages
- [ ] Test that the close button (X) appears on non-homepage routes and navigates back to home correctly

### Notes

This is part of an efficiency audit of the codebase. A full report documenting additional efficiency improvements was created locally but not committed to the repo.

**Link to Devin run:** https://staging.itsdev.in/sessions/b5ffb7d9fa104ffe81b60ab2daa399c3
**Requested by:** Joseph Zhang (@josephz-me)
<!-- devin-review-badge-begin -->

---

<a href="https://staging.itsdev.in/review/josephz-me/portfolio-v4/pull/29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
